### PR TITLE
fix: standardize TODO comment format in ollama.py

### DIFF
--- a/python/python/lancedb/embeddings/ollama.py
+++ b/python/python/lancedb/embeddings/ollama.py
@@ -59,5 +59,5 @@ class OllamaEmbeddings(TextEmbeddingFunction):
     @cached_property
     def _ollama_client(self) -> "ollama.Client":
         ollama = attempt_import_or_raise("ollama")
-        # ToDo explore ollama.AsyncClient
+        # TODO explore ollama.AsyncClient
         return ollama.Client(host=self.host, **self.ollama_client_kwargs)


### PR DESCRIPTION
## Summary

- Fixed inconsistent "ToDo" comment format to "TODO" in `ollama.py`
- Ensures consistency across the codebase (28 other locations use "TODO")

## Test plan

- [x] No functional changes, only comment formatting
- [x] Pre-commit hooks pass (ruff, formatting)

🤖 Generated with [Claude Code](https://claude.ai/code)