### PR TITLE
fix: use python3 for venv creation in contributing guide

### DIFF
--- a/python/CONTRIBUTING.md
+++ b/python/CONTRIBUTING.md
@@ -23,7 +23,7 @@ To set up your development environment, you will need to install the following:
 Create a virtual environment to work in:
 
 ```bash
-python -m venv venv
+python3 -m venv venv
 source venv/bin/activate
 pip install maturin
 ```


### PR DESCRIPTION
Use python3 instead of python for virtual environment creation since python may not map to python3 outside venv, e.g. on macOS.