### PR TITLE
fix: replace broken documentation URLs in error messages

### DIFF
--- a/python/python/lancedb/common.py
+++ b/python/python/lancedb/common.py
@@ -94,9 +94,9 @@ def data_to_reader(
     else:
         raise TypeError(
             f"Unknown data type {type(data)}. "
-            "Please check "
-            "https://lancedb.github.io/lance/read_and_write.html "
-            "to see supported types."
+            "Supported types: list of dicts, pandas DataFrame, polars DataFrame, "
+            "pyarrow Table/RecordBatch, or Pydantic models. "
+            "See https://lancedb.github.io/lancedb/guides/tables/ for examples."
         )
 
 

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -165,9 +165,9 @@ def _into_pyarrow_reader(data) -> pa.RecordBatchReader:
     else:
         raise TypeError(
             f"Unknown data type {type(data)}. "
-            "Please check "
-            "https://lancedb.github.io/lancedb/python/python/ "
-            "to see supported types."
+            "Supported types: list of dicts, pandas DataFrame, polars DataFrame, "
+            "pyarrow Table/RecordBatch, or Pydantic models. "
+            "See https://lancedb.github.io/lancedb/guides/tables/ for examples."
         )
 
 


### PR DESCRIPTION
Replaces broken 404 URL and unhelpful documentation links in type error messages with working URL and inline list of supported data types.

**Before**: Points to https://lancedb.github.io/lance/read_and_write.html (404 error)  
**After**: Lists supported types inline and points to https://lancedb.github.io/lancedb/guides/tables/